### PR TITLE
Remove test duplicate

### DIFF
--- a/tests/Mocks/InCollectionSpecification.php
+++ b/tests/Mocks/InCollectionSpecification.php
@@ -6,7 +6,6 @@ use \Mbrevda\SpecificationPattern\CompositeSpecification;
 
 class InCollectionSpecification extends CompositeSpecification
 {
-
     public function isSatisfiedBy($candidate)
     {
         return $candidate->isInCollection;

--- a/tests/Mocks/NoticeNotSentSpecification.php
+++ b/tests/Mocks/NoticeNotSentSpecification.php
@@ -6,7 +6,6 @@ use \Mbrevda\SpecificationPattern\CompositeSpecification;
 
 class NoticeNotSentSpecification extends CompositeSpecification
 {
-
     public function isSatisfiedBy($candidate)
     {
         return $candidate->hasSentNotice == false;

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -60,7 +60,7 @@ class Tests extends \PHPUnit_Framework_TestCase
     {
         $spec = $this->overDue
             ->andX($this->noticeNotSent)
-            ->not(new NotSpecification($this->inCollection));
+            ->not();
         $this->assertCount(2, $this->usingSpec($spec));
     }
 

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -64,14 +64,6 @@ class Tests extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $this->usingSpec($spec));
     }
 
-    public function testAndandNot()
-    {
-        $spec = $this->overDue
-            ->andX($this->noticeNotSent)
-            ->not(new NotSpecification($this->inCollection));
-        $this->assertCount(2, $this->usingSpec($spec));
-    }
-
     public function testOr()
     {
         $spec = $this->overDue


### PR DESCRIPTION
* Tests `testAndandNot` and `testAndXandNot` are identical.
* Argument of `not()` method is [not used](https://github.com/mbrevda/SpecificationPattern/blob/2aaa9b25d659abea3fbc9a21939a10aab0b39feb/src/CompositeSpecification.php#L24). I remove it.